### PR TITLE
Fix HVMS

### DIFF
--- a/HVM3.cabal
+++ b/HVM3.cabal
@@ -42,23 +42,23 @@ executable hvml
     extra-libraries:  c
     ghc-options:     -Wno-all
 
---executable hvms
---    import:           warnings
---    main-is:          HVMS/Main.hs
---    other-modules:    HVMS.Type
---                    , HVMS.Extract
---                    , HVMS.Inject
---                    , HVMS.Normal
---                    , HVMS.Parse
---                    , HVMS.Show
---    build-depends:    base ^>=4.20.0.0,
---                      mtl ^>=2.3.1,
---                      containers ^>=0.7,
---                      unordered-containers ^>=0.2.19.1,
---                      parsec ^>=3.1.17.0,
---                      hashable ^>=1.5.0.0,
---    hs-source-dirs:   src
---    default-language: GHC2024
---    c-sources:        src/HVMS/Runtime.c
---    extra-libraries:  c
---    ghc-options:     -Wno-all
+executable hvms
+    import:           warnings
+    main-is:          HVMS/Main.hs
+    other-modules:    HVMS.Type
+                    , HVMS.Extract
+                    , HVMS.Inject
+                    , HVMS.Normal
+                    , HVMS.Parse
+                    , HVMS.Show
+    build-depends:    base ^>=4.20.0.0,
+                      mtl ^>=2.3.1,
+                      containers ^>=0.7,
+                      unordered-containers ^>=0.2.19.1,
+                      parsec ^>=3.1.17.0,
+                      hashable ^>=1.5.0.0,
+    hs-source-dirs:   src
+    default-language: GHC2024
+    c-sources:        src/HVMS/Runtime.c
+    extra-libraries:  c
+    ghc-options:     -Wno-all

--- a/src/HVMS/Extract.hs
+++ b/src/HVMS/Extract.hs
@@ -10,13 +10,13 @@ extractPCore :: Term -> IO PCore
 extractPCore term = case termTag term of
   tag | tag == _NUL_ -> return PNul
       | tag == _VAR_ -> do
-          get <- get (termLoc term)
-          extractVar (termLoc term) get
+          got <- get (termLoc term)
+          extractVar (termLoc term) got
       | tag == _LAM_ -> do
           let loc = termLoc term
           var <- get (loc + 0)
           bod <- get (loc + 1)
-          var' <- extractNCore var
+          var' <- extractNCore (loc + 0) var
           bod' <- extractPCore bod
           return $ PLam var' bod'
       | tag == _SUP_ -> do
@@ -28,74 +28,66 @@ extractPCore term = case termTag term of
           return $ PSup tm1' tm2'
       | otherwise -> return PNul
 
-extractNCore :: Term -> IO NCore
-extractNCore term = case termTag term of
+-- Convert a term in memory to a NCore.
+-- The optional location is the location of the term
+-- being extracted in the buffer.
+extractNCore :: Loc -> Term -> IO NCore
+extractNCore loc term = case termTag term of
   tag | tag == _ERA_ -> return NEra
-      | tag == _SUB_ -> do
-          get <- get (termLoc term)
-          extractSub (termLoc term) get
+      | tag == _SUB_ -> return $ NSub ("v" ++ show loc)
       | tag == _APP_ -> do
           let loc = termLoc term
           arg <- get (loc + 0)
           ret <- get (loc + 1)
           arg' <- extractPCore arg
-          ret' <- extractNCore ret
+          ret' <- extractNCore (loc + 1) ret
           return $ NApp arg' ret'
       | tag == _DUP_ -> do
           let loc = termLoc term
           dp1 <- get (loc + 0)
           dp2 <- get (loc + 1)
-          dp1' <- extractNCore dp1
-          dp2' <- extractNCore dp2
+          dp1' <- extractNCore (loc + 0) dp1
+          dp2' <- extractNCore (loc + 1) dp2
           return $ NDup dp1' dp2'
       | otherwise -> return NEra
 
 extractVar :: Loc -> Term -> IO PCore
-extractVar var term = case termTag term of
+extractVar loc term = case termTag term of
   tag | tag == _VAR_ -> extractPCore term
       | tag == _NUL_ -> extractPCore term
       | tag == _LAM_ -> extractPCore term
       | tag == _SUP_ -> extractPCore term
-      | tag == _SUB_ -> if termLoc term == var
-                        then return $ PVar (show var)
-                        else extractPCore (termNew _SUB_ 0 (termLoc term))
-      | otherwise -> return PNul
-
-extractSub :: Loc -> Term -> IO NCore
-extractSub sub term = case termTag term of
-  tag | tag == _VAR_ -> extractNCore term
-      | tag == _ERA_ -> extractNCore term
-      | tag == _APP_ -> extractNCore term
-      | tag == _DUP_ -> extractNCore term
-      | tag == _SUB_ -> if termLoc term == sub
-                        then return $ NSub (show sub)
-                        else extractNCore (termNew _SUB_ 0 (termLoc term))
-      | otherwise -> return NEra
+      | tag == _SUB_ -> return $ PVar ("v" ++ show loc)
+      | otherwise    -> return PNul
 
 -- Bag and Net Extraction
 -- ---------------------
 
-extractDex :: (Term, Term) -> IO Dex
-extractDex (neg, pos) = do
-  neg' <- extractNCore neg
+extractDex :: Loc -> IO Dex
+extractDex loc = do
+  neg  <- get (loc + 0)
+  pos  <- get (loc + 1)
+  neg' <- extractNCore (loc + 0) neg
   pos' <- extractPCore pos
   return (neg', pos')
 
-extractBag :: [(Word64, (Term, Term))] -> IO Bag
+extractBag :: [Loc] -> IO Bag
 extractBag [] = return []
-extractBag ((_, dex):dexs) = do
-  dex' <- extractDex dex
-  dexs' <- extractBag dexs
-  return (dex' : dexs')
+extractBag (loc:locs) = do
+  dex  <- extractDex loc
+  dexs <- extractBag locs
+  return (dex : dexs)
 
-extractNet :: Term -> [(Word64, (Term, Term))] -> IO Net
-extractNet root bag = do
+extractNet :: Term -> IO Net
+extractNet root = do
   root' <- extractPCore root
-  bag' <- extractBag bag
-  return $ Net root' bag'
+  ini   <- rbagIni
+  end   <- rbagEnd
+  bag   <- extractBag [ini, ini+2..end-2]
+  return $ Net root' bag
 
 -- Main Entry Points
 -- ----------------
 
-doExtractNet :: Term -> [(Word64, (Term, Term))] -> IO Net
-doExtractNet root bag = extractNet root bag
+doExtractNet :: Term -> IO Net
+doExtractNet root = extractNet root

--- a/src/HVMS/Extract.hs
+++ b/src/HVMS/Extract.hs
@@ -10,19 +10,19 @@ extractPCore :: Term -> IO PCore
 extractPCore term = case termTag term of
   tag | tag == _NUL_ -> return PNul
       | tag == _VAR_ -> do
-          got <- got (termLoc term)
-          extractVar (termLoc term) got
+          get <- get (termLoc term)
+          extractVar (termLoc term) get
       | tag == _LAM_ -> do
           let loc = termLoc term
-          var <- got (loc + 0)
-          bod <- got (loc + 1)
+          var <- get (loc + 0)
+          bod <- get (loc + 1)
           var' <- extractNCore var
           bod' <- extractPCore bod
           return $ PLam var' bod'
       | tag == _SUP_ -> do
           let loc = termLoc term
-          tm1 <- got (loc + 0)
-          tm2 <- got (loc + 1)
+          tm1 <- get (loc + 0)
+          tm2 <- get (loc + 1)
           tm1' <- extractPCore tm1
           tm2' <- extractPCore tm2
           return $ PSup tm1' tm2'
@@ -32,25 +32,25 @@ extractNCore :: Term -> IO NCore
 extractNCore term = case termTag term of
   tag | tag == _ERA_ -> return NEra
       | tag == _SUB_ -> do
-          got <- got (termLoc term)
-          extractSub (termLoc term) got
+          get <- get (termLoc term)
+          extractSub (termLoc term) get
       | tag == _APP_ -> do
           let loc = termLoc term
-          arg <- got (loc + 0)
-          ret <- got (loc + 1)
+          arg <- get (loc + 0)
+          ret <- get (loc + 1)
           arg' <- extractPCore arg
           ret' <- extractNCore ret
           return $ NApp arg' ret'
       | tag == _DUP_ -> do
           let loc = termLoc term
-          dp1 <- got (loc + 0)
-          dp2 <- got (loc + 1)
+          dp1 <- get (loc + 0)
+          dp2 <- get (loc + 1)
           dp1' <- extractNCore dp1
           dp2' <- extractNCore dp2
           return $ NDup dp1' dp2'
       | otherwise -> return NEra
 
-extractVar :: Word64 -> Term -> IO PCore
+extractVar :: Loc -> Term -> IO PCore
 extractVar var term = case termTag term of
   tag | tag == _VAR_ -> extractPCore term
       | tag == _NUL_ -> extractPCore term
@@ -61,7 +61,7 @@ extractVar var term = case termTag term of
                         else extractPCore (termNew _SUB_ 0 (termLoc term))
       | otherwise -> return PNul
 
-extractSub :: Word64 -> Term -> IO NCore
+extractSub :: Loc -> Term -> IO NCore
 extractSub sub term = case termTag term of
   tag | tag == _VAR_ -> extractNCore term
       | tag == _ERA_ -> extractNCore term

--- a/src/HVMS/Inject.hs
+++ b/src/HVMS/Inject.hs
@@ -14,7 +14,7 @@ injectPCore :: PCore -> Maybe Word64 -> VarMap -> IO (VarMap, Term)
 injectPCore (PVar nam) host vars = case Map.lookup nam vars of
   Just neg_host -> return (vars, termNew _VAR_ 0 neg_host)
   Nothing       -> return (vars, termNew _NUL_ 0 0)
-injectPCore PNul _ vars = 
+injectPCore PNul _ vars =
   return (vars, termNew _NUL_ 0 0)
 injectPCore (PLam var bod) host vars = do
   lam <- allocNode 2

--- a/src/HVMS/Inject.hs
+++ b/src/HVMS/Inject.hs
@@ -37,17 +37,14 @@ injectPCore (PSup tm1 tm2) loc vars = do
 
 injectNCore :: NCore -> Maybe Loc -> VarMap -> IO (VarMap, Term)
 injectNCore (NSub name) loc vars = case (Map.lookup name vars, loc) of
-  -- we've seen the positive end of this var already, so we should mutate
-  -- it to hold the SUB's location.
   (Just pos_loc, Just neg_host) -> do
-    putStrLn $ "injectNCore: set pos_loc=" ++ show pos_loc ++ " for name=" ++ name
+    -- we've seen the positive end of this var already, so we should mutate
+    -- it to hold the SUB's location.
     set pos_loc (termNew _VAR_ 0 neg_host)
     return (Map.delete name vars, termNew _SUB_ 0 0)
   -- we haven't seen the positive end of this var yet, so we save the
-  -- SUB's location so the positive VAR can reference it.
-  (Nothing, Just neg_host)      -> do
-    putStrLn $ "injectNCore: insert name=" ++ name ++ " neg_host=" ++ show neg_host
-    return (Map.insert name neg_host vars, termNew _SUB_ 0 0)
+  -- SUB's location so the VAR can reference it.
+  (Nothing, Just neg_host)      -> return (Map.insert name neg_host vars, termNew _SUB_ 0 0)
   _                             -> do
     putStrLn $ "injectNCore: invalid SUB (" ++ name ++ ")"
     return (vars, _VOID_)
@@ -83,6 +80,7 @@ injectNet (Net root bag) vars = do
   root_loc <- allocNode 1
   (vars, root) <- injectPCore root (Just root_loc) vars
   vars <- foldr (\dex acc -> acc >>= injectDex dex) (return vars) bag
+  root <- get root_loc
   return (vars, root)
 
 -- Main Entry Points

--- a/src/HVMS/Inject.hs
+++ b/src/HVMS/Inject.hs
@@ -5,25 +5,29 @@ import qualified Data.Map as Map
 import HVMS.Type
 
 -- Variable Map
-type VarMap = Map.Map String Word64
+type VarMap = Map.Map String Loc
 
 -- Core to Runtime
 -- --------------
 
-injectPCore :: PCore -> Maybe Word64 -> VarMap -> IO (VarMap, Term)
-injectPCore (PVar nam) host vars = case Map.lookup nam vars of
-  Just neg_host -> return (vars, termNew _VAR_ 0 neg_host)
-  Nothing       -> return (vars, termNew _NUL_ 0 0)
+injectPCore :: PCore -> Maybe Loc -> VarMap -> IO (VarMap, Term)
+injectPCore (PVar name) loc vars = case (Map.lookup name vars, loc) of
+  -- temporary node that will be mutated when the negative end of this variable is injected.
+  (Nothing, Just pos_loc) -> return (Map.insert name pos_loc vars, termNew _NUL_ 0 0)
+  (Just neg_loc, _      ) -> return (Map.delete name vars, termNew _VAR_ 0 neg_loc)
+  _                       -> do
+    putStrLn $ "injectPCore: invalid VAR (" ++ name ++ ")"
+    return (vars, _VOID_)
 injectPCore PNul _ vars =
   return (vars, termNew _NUL_ 0 0)
-injectPCore (PLam var bod) host vars = do
+injectPCore (PLam var bod) loc vars = do
   lam <- allocNode 2
   (vars, var) <- injectNCore var (Just (lam + 0)) vars
   (vars, bod) <- injectPCore bod (Just (lam + 1)) vars
   set (lam + 0) var
   set (lam + 1) bod
   return (vars, termNew _LAM_ 0 lam)
-injectPCore (PSup tm1 tm2) host vars = do
+injectPCore (PSup tm1 tm2) loc vars = do
   sup <- allocNode 2
   (vars, tm1) <- injectPCore tm1 (Just (sup + 0)) vars
   (vars, tm2) <- injectPCore tm2 (Just (sup + 1)) vars
@@ -31,20 +35,32 @@ injectPCore (PSup tm1 tm2) host vars = do
   set (sup + 1) tm2
   return (vars, termNew _SUP_ 0 sup)
 
-injectNCore :: NCore -> Maybe Word64 -> VarMap -> IO (VarMap, Term)
-injectNCore (NSub nam) host vars = case Map.lookup nam vars of
-  Just pos_host -> return (vars, termNew _SUB_ 0 pos_host)
-  Nothing       -> return (vars, termNew _ERA_ 0 0)
+injectNCore :: NCore -> Maybe Loc -> VarMap -> IO (VarMap, Term)
+injectNCore (NSub name) loc vars = case (Map.lookup name vars, loc) of
+  -- we've seen the positive end of this var already, so we should mutate
+  -- it to hold the SUB's location.
+  (Just pos_loc, Just neg_host) -> do
+    putStrLn $ "injectNCore: set pos_loc=" ++ show pos_loc ++ " for name=" ++ name
+    set pos_loc (termNew _VAR_ 0 neg_host)
+    return (Map.delete name vars, termNew _SUB_ 0 0)
+  -- we haven't seen the positive end of this var yet, so we save the
+  -- SUB's location so the positive VAR can reference it.
+  (Nothing, Just neg_host)      -> do
+    putStrLn $ "injectNCore: insert name=" ++ name ++ " neg_host=" ++ show neg_host
+    return (Map.insert name neg_host vars, termNew _SUB_ 0 0)
+  _                             -> do
+    putStrLn $ "injectNCore: invalid SUB (" ++ name ++ ")"
+    return (vars, _VOID_)
 injectNCore NEra _ vars =
   return (vars, termNew _ERA_ 0 0)
-injectNCore (NApp arg ret) host vars = do
+injectNCore (NApp arg ret) loc vars = do
   app <- allocNode 2
   (vars, arg) <- injectPCore arg (Just (app + 0)) vars
   (vars, ret) <- injectNCore ret (Just (app + 1)) vars
   set (app + 0) arg
   set (app + 1) ret
   return (vars, termNew _APP_ 0 app)
-injectNCore (NDup dp1 dp2) host vars = do
+injectNCore (NDup dp1 dp2) loc vars = do
   dup <- allocNode 2
   (vars, dp1) <- injectNCore dp1 (Just (dup + 0)) vars
   (vars, dp2) <- injectNCore dp2 (Just (dup + 1)) vars
@@ -59,16 +75,15 @@ injectDex :: Dex -> VarMap -> IO VarMap
 injectDex (neg, pos) vars = do
   (vars, neg) <- injectNCore neg Nothing vars
   (vars, pos) <- injectPCore pos Nothing vars
-  loc <- allocNode 2
-  set (loc + 0) neg
-  set (loc + 1) pos
+  rbagPush neg pos
   return vars
 
 injectNet :: Net -> VarMap -> IO (VarMap, Term)
-injectNet (Net rot bag) vars = do
-  (vars, rot) <- injectPCore rot (Just 0) vars
+injectNet (Net root bag) vars = do
+  root_loc <- allocNode 1
+  (vars, root) <- injectPCore root (Just root_loc) vars
   vars <- foldr (\dex acc -> acc >>= injectDex dex) (return vars) bag
-  return (vars, rot)
+  return (vars, root)
 
 -- Main Entry Points
 -- ----------------

--- a/src/HVMS/Main.hs
+++ b/src/HVMS/Main.hs
@@ -42,18 +42,12 @@ cliRun filePath showStats = do
     Right net -> pure net
     Left  err -> exitWithError ("ParserError: " ++ err)
 
-  print net
   root <- doInjectNet net
-
-  dumpBuff
-
-  print "printing root"
-  print root
-
+  net' <- doExtractNet root
   norm <- normal root
 
   set 0 norm
-  norm' <- doExtractNet norm []
+  norm' <- doExtractNet norm
   putStrLn $ netToString norm'
 
   when showStats $ do
@@ -72,7 +66,7 @@ cliRun filePath showStats = do
 printHelp :: IO ()
 printHelp = do
   putStrLn "HVM-Strict usage:"
-  putStrLn "  hvms run [-s] <file>  # Normalizes the specified file"
+  putStrLn "  hvms run <file> [-s]  # Normalizes the specified file"
   putStrLn "  hvms help             # Shows this help message"
 
 exitWithError :: String -> IO a

--- a/src/HVMS/Main.hs
+++ b/src/HVMS/Main.hs
@@ -43,8 +43,13 @@ cliRun filePath showStats = do
     Left  err -> exitWithError ("ParserError: " ++ err)
 
   print net
-
   root <- doInjectNet net
+
+  dumpBuff
+
+  print "printing root"
+  print root
+
   norm <- normal root
 
   set 0 norm

--- a/src/HVMS/Normal.hs
+++ b/src/HVMS/Normal.hs
@@ -17,7 +17,7 @@ normalize net = do
   norm <- normal root
 
   -- Convert back to core terms
-  result <- doExtractNet norm []
+  result <- doExtractNet norm
 
   -- Cleanup runtime
   hvmFree

--- a/src/HVMS/Normal.hs
+++ b/src/HVMS/Normal.hs
@@ -9,19 +9,19 @@ normalize :: Net -> IO Net
 normalize net = do
   -- Initialize runtime
   hvmInit
-  
+
   -- Convert to runtime terms
   root <- doInjectNet net
-  
+
   -- Normalize using C runtime
   norm <- normal root
-  
+
   -- Convert back to core terms
   result <- doExtractNet norm []
-  
+
   -- Cleanup runtime
   hvmFree
-  
+
   return result
 
 -- | Normalizes a term, returning Nothing if it fails

--- a/src/HVMS/Runtime.c
+++ b/src/HVMS/Runtime.c
@@ -191,6 +191,7 @@ static void interact_duplam(Loc a_loc, Loc b_loc) {
   Loc  dp1 = port(1, a_loc);
   Loc  dp2 = port(2, a_loc);
   Loc  var = port(1, b_loc);
+  // TODO(enricozb): why is this the only take?
   Term bod = take(port(2, b_loc));
   Loc  co1 = alloc_node(2);
   Loc  co2 = alloc_node(2);
@@ -273,7 +274,6 @@ static int normal_step() {
     return 0;
   }
 
-  // TODO(enricozb): change to take(..) instead of get(..) / set(.., 0)
   Term neg = take(loc + 0);
   Term pos = take(loc + 1);
 

--- a/src/HVMS/Runtime.c
+++ b/src/HVMS/Runtime.c
@@ -7,72 +7,83 @@
 #include <string.h>
 #include <time.h>
 
-// Constants
-#define VAR 0x01
-#define SUB 0x02
-#define NUL 0x03
-#define ERA 0x04
-#define LAM 0x05
-#define APP 0x06
-#define SUP 0x07
-#define DUP 0x08
+typedef uint8_t  Tag;  //  8 bits
+typedef uint32_t Lab;  // 24 bits
+typedef uint32_t Loc;  // 32 bits
+typedef uint64_t Term; // Loc | Lab | Tag
+typedef uint32_t u32;
+typedef uint64_t u64;
 
-#define VOID 0x0000000000000000
-#define RBAG 0x100000000
+// Constants
+const Tag VAR = 0x01;
+const Tag SUB = 0x02;
+const Tag NUL = 0x03;
+const Tag ERA = 0x04;
+const Tag LAM = 0x05;
+const Tag APP = 0x06;
+const Tag SUP = 0x07;
+const Tag DUP = 0x08;
+
+const Term VOID = 0;
 
 // Types
 typedef uint64_t u64;
 typedef _Atomic(u64) a64;
 
 // Global heap
-static a64* BUFF = NULL;
+static a64* BUFF     = NULL;
 static u64  RNOD_INI = 0;
 static u64  RNOD_END = 0;
+static u64  RBAG     = 0x100000000;
 static u64  RBAG_INI = 0;
 static u64  RBAG_END = 0;
 
 // Term operations
-static inline u64 term_new(u64 tag, u64 lab, u64 loc) {
-  return tag | (lab << 8) | (loc << 32);
+Term term_new(Tag tag, Lab lab, Loc loc) {
+  Term tag_enc = tag;
+  Term lab_enc = ((Term)lab) << 8;
+  Term loc_enc = ((Term)loc) << 32;
+
+  return loc_enc | lab_enc | tag_enc;
 }
 
-static inline u64 term_tag(u64 term) {
+Tag term_tag(Term term) {
   return term & 0xFF;
 }
 
-static inline u64 term_lab(u64 term) {
+Lab term_lab(Term term) {
   return (term >> 8) & 0xFFFFFF;
 }
 
-static inline u64 term_loc(u64 term) {
+Loc term_loc(Term term) {
   return (term >> 32) & 0xFFFFFFFF;
 }
 
-static inline u64 port(u64 n, u64 x) {
-  return n + x - 1;
-}
-
 // Memory operations
-static inline u64 swap(u64 loc, u64 term) {
+Term swap(Loc loc, Term term) {
   return atomic_exchange_explicit(&BUFF[loc], term, memory_order_relaxed);
 }
 
-static inline u64 got(u64 loc) {
+Term got(Loc loc) {
   return atomic_load_explicit(&BUFF[loc], memory_order_relaxed);
 }
 
-static inline void set(u64 loc, u64 term) {
+void set(Loc loc, Term term) {
   atomic_store_explicit(&BUFF[loc], term, memory_order_relaxed);
 }
 
+Loc port(u64 n, Loc x) {
+  return n + x - 1;
+}
+
 // Allocation
-static inline u64 alloc_node(u64 arity) {
+Loc alloc_node(u64 arity) {
   u64 loc = RNOD_END;
   RNOD_END += arity;
   return loc;
 }
 
-static inline u64 inc_itr() {
+u64 inc_itr() {
   return RBAG_END / 2;
 }
 
@@ -101,24 +112,24 @@ static void move(u64 neg_loc, u64 pos) {
 }
 
 // Interactions
-static void interact_applam(u64 a_loc, u64 b_loc) {
-  u64 arg = swap(port(1, a_loc), VOID);
-  u64 ret = port(2, a_loc);
-  u64 var = port(1, b_loc);
-  u64 bod = swap(port(2, b_loc), VOID);
+static void interact_applam(Loc a_loc, Loc b_loc) {
+  Term arg = swap(port(1, a_loc), VOID);
+  Loc  ret = port(2, a_loc);
+  Loc  var = port(1, b_loc);
+  Term bod = swap(port(2, b_loc), VOID);
   move(var, arg);
   move(ret, bod);
 }
 
-static void interact_appsup(u64 a_loc, u64 b_loc) {
-  u64 arg = swap(port(1, a_loc), VOID);
-  u64 ret = port(2, a_loc);
-  u64 tm1 = swap(port(1, b_loc), VOID);
-  u64 tm2 = swap(port(2, b_loc), VOID);
-  u64 dp1 = alloc_node(2);
-  u64 dp2 = alloc_node(2);
-  u64 cn1 = alloc_node(2);
-  u64 cn2 = alloc_node(2);
+static void interact_appsup(Loc a_loc, Loc b_loc) {
+  Term arg = swap(port(1, a_loc), VOID);
+  Loc  ret = port(2, a_loc);
+  Term tm1 = swap(port(1, b_loc), VOID);
+  Term tm2 = swap(port(2, b_loc), VOID);
+  Loc  dp1 = alloc_node(2);
+  Loc  dp2 = alloc_node(2);
+  Loc  cn1 = alloc_node(2);
+  Loc  cn2 = alloc_node(2);
   set(port(1, dp1), term_new(SUB, 0, port(1, dp1)));
   set(port(2, dp1), term_new(SUB, 0, port(2, dp1)));
   set(port(1, dp2), term_new(VAR, 0, port(2, cn1)));
@@ -133,31 +144,31 @@ static void interact_appsup(u64 a_loc, u64 b_loc) {
   link(term_new(APP, 0, cn2), tm2);
 }
 
-static void interact_appnul(u64 a_loc) {
-  u64 arg = swap(port(1, a_loc), VOID);
-  u64 ret = port(2, a_loc);
+static void interact_appnul(Loc a_loc) {
+  Term arg = swap(port(1, a_loc), VOID);
+  Loc  ret = port(2, a_loc);
   link(term_new(ERA, 0, 0), arg);
   move(ret, term_new(NUL, 0, 0));
 }
 
-static void interact_dupsup(u64 a_loc, u64 b_loc) {
-  u64 dp1 = port(1, a_loc);
-  u64 dp2 = port(2, a_loc);
-  u64 tm1 = swap(port(1, b_loc), VOID);
-  u64 tm2 = swap(port(2, b_loc), VOID);
+static void interact_dupsup(Loc a_loc, Loc b_loc) {
+  Loc  dp1 = port(1, a_loc);
+  Loc  dp2 = port(2, a_loc);
+  Term tm1 = swap(port(1, b_loc), VOID);
+  Term tm2 = swap(port(2, b_loc), VOID);
   move(dp1, tm1);
   move(dp2, tm2);
 }
 
-static void interact_duplam(u64 a_loc, u64 b_loc) {
-  u64 dp1 = port(1, a_loc);
-  u64 dp2 = port(2, a_loc);
-  u64 var = port(1, b_loc);
-  u64 bod = swap(port(2, b_loc), VOID);
-  u64 co1 = alloc_node(2);
-  u64 co2 = alloc_node(2);
-  u64 du1 = alloc_node(2);
-  u64 du2 = alloc_node(2);
+static void interact_duplam(Loc a_loc, Loc b_loc) {
+  Loc  dp1 = port(1, a_loc);
+  Loc  dp2 = port(2, a_loc);
+  Loc  var = port(1, b_loc);
+  Term bod = swap(port(2, b_loc), VOID);
+  Loc  co1 = alloc_node(2);
+  Loc  co2 = alloc_node(2);
+  Loc  du1 = alloc_node(2);
+  Loc  du2 = alloc_node(2);
   set(port(1, co1), term_new(SUB, 0, port(1, co1)));
   set(port(2, co1), term_new(VAR, 0, port(1, du2)));
   set(port(1, co2), term_new(SUB, 0, port(1, co2)));
@@ -179,25 +190,25 @@ static void interact_dupnul(u64 a_loc) {
   move(dp2, term_new(NUL, 0, 0));
 }
 
-static void interact_eralam(u64 b_loc) {
-  u64 var = port(1, b_loc);
-  u64 bod = swap(port(2, b_loc), VOID);
+static void interact_eralam(Loc b_loc) {
+  Loc  var = port(1, b_loc);
+  Term bod = swap(port(2, b_loc), VOID);
   move(var, term_new(NUL, 0, 0));
   link(term_new(ERA, 0, 0), bod);
 }
 
-static void interact_erasup(u64 b_loc) {
-  u64 tm1 = swap(port(1, b_loc), VOID);
-  u64 tm2 = swap(port(2, b_loc), VOID);
+static void interact_erasup(Loc b_loc) {
+  Term tm1 = swap(port(1, b_loc), VOID);
+  Term tm2 = swap(port(2, b_loc), VOID);
   link(term_new(ERA, 0, 0), tm1);
   link(term_new(ERA, 0, 0), tm2);
 }
 
-static void interact(u64 a, u64 b) {
-  u64 a_tag = term_tag(a);
-  u64 b_tag = term_tag(b);
-  u64 a_loc = term_loc(a);
-  u64 b_loc = term_loc(b);
+static void interact(Term a, Term b) {
+  Tag a_tag = term_tag(a);
+  Tag b_tag = term_tag(b);
+  Loc a_loc = term_loc(a);
+  Loc b_loc = term_loc(b);
   switch (a_tag) {
     case APP:
       switch (b_tag) {
@@ -226,15 +237,16 @@ static void interact(u64 a, u64 b) {
 // Evaluation
 static int normal_step() {
   if (RBAG_INI < RBAG_END) {
-    u64 loc = RBAG + RBAG_INI;
-    u64 neg = got(loc + 0);
-    u64 pos = got(loc + 1);
+    Loc  loc = RBAG + RBAG_INI;
+    Term neg = got(loc + 0);
+    Term pos = got(loc + 1);
     set(loc + 0, VOID);
     set(loc + 1, VOID);
     interact(neg, pos);
     RBAG_INI += 2;
     return 1;
   }
+
   return 0;
 }
 
@@ -256,8 +268,9 @@ void hvm_free() {
   }
 }
 
-u64 normal(u64 term) {
+Term normal(Term term) {
   while (normal_step());
+
   return term;
 }
 

--- a/src/HVMS/Show.hs
+++ b/src/HVMS/Show.hs
@@ -44,10 +44,10 @@ tagToString tag
   | tag == _DUP_ = "DUP"
   | otherwise    = "???"
 
-labToString :: Word64 -> String
+labToString :: Lab -> String
 labToString lab = padLeft (showHex lab "") 6 '0'
 
-locToString :: Word64 -> String
+locToString :: Loc -> String
 locToString loc = padLeft (showHex loc "") 9 '0'
 
 termToString :: Term -> String

--- a/src/HVMS/Type.hs
+++ b/src/HVMS/Type.hs
@@ -88,6 +88,12 @@ foreign import ccall unsafe "Runtime.c set"
 foreign import ccall unsafe "Runtime.c rbag_push"
   rbagPush :: Term -> Term -> IO ()
 
+foreign import ccall unsafe "Runtime.c rbag_ini"
+  rbagIni :: IO Loc
+
+foreign import ccall unsafe "Runtime.c rbag_end"
+  rbagEnd :: IO Loc
+
 -- foreign import ccall unsafe "Runtime.c take"
 --   take :: Loc -> IO Term
 

--- a/src/HVMS/Type.hs
+++ b/src/HVMS/Type.hs
@@ -76,8 +76,8 @@ foreign import ccall unsafe "Runtime.c term_lab"
 foreign import ccall unsafe "Runtime.c term_loc"
   termLoc :: Term -> Loc
 
-foreign import ccall unsafe "Runtime.c term_key"
-  termKey :: Term -> Loc
+-- foreign import ccall unsafe "Runtime.c term_key"
+--   termKey :: Term -> Loc
 
 foreign import ccall unsafe "Runtime.c swap"
   swap :: Loc -> Term -> IO Term
@@ -88,8 +88,8 @@ foreign import ccall unsafe "Runtime.c got"
 foreign import ccall unsafe "Runtime.c set"
   set :: Loc -> Term -> IO ()
 
-foreign import ccall unsafe "Runtime.c take"
-  take :: Loc -> IO Term
+-- foreign import ccall unsafe "Runtime.c take"
+--   take :: Loc -> IO Term
 
 foreign import ccall unsafe "Runtime.c alloc_node"
   allocNode :: Word64 -> IO Word64

--- a/src/HVMS/Type.hs
+++ b/src/HVMS/Type.hs
@@ -35,9 +35,9 @@ data Net = Net
 -- Runtime Types
 -- -------------
 
-type Tag  = Word64
-type Lab  = Word64
-type Loc  = Word64
+type Tag  = Word8
+type Lab  = Word32
+type Loc  = Word32
 type Term = Word64
 
 -- Runtime constants
@@ -52,10 +52,7 @@ _SUP_ = 0x07
 _DUP_ = 0x08
 
 _VOID_ :: Term
-_VOID_ = 0x00000000_000000_00
-
-_RBAG_ :: Word64
-_RBAG_ = 0x1_0000_0000
+_VOID_ = 0x0
 
 -- FFI imports
 foreign import ccall unsafe "Runtime.c hvm_init"
@@ -82,20 +79,26 @@ foreign import ccall unsafe "Runtime.c term_loc"
 foreign import ccall unsafe "Runtime.c swap"
   swap :: Loc -> Term -> IO Term
 
-foreign import ccall unsafe "Runtime.c got"
-  got :: Loc -> IO Term
+foreign import ccall unsafe "Runtime.c get"
+  get :: Loc -> IO Term
 
 foreign import ccall unsafe "Runtime.c set"
   set :: Loc -> Term -> IO ()
+
+foreign import ccall unsafe "Runtime.c rbag_push"
+  rbagPush :: Term -> Term -> IO ()
 
 -- foreign import ccall unsafe "Runtime.c take"
 --   take :: Loc -> IO Term
 
 foreign import ccall unsafe "Runtime.c alloc_node"
-  allocNode :: Word64 -> IO Word64
+  allocNode :: Word64 -> IO Loc
 
 foreign import ccall unsafe "Runtime.c inc_itr"
   incItr :: IO Word64
 
 foreign import ccall unsafe "Runtime.c normal"
   normal :: Term -> IO Term
+
+foreign import ccall unsafe "Runtime.c dump_buff"
+  dumpBuff :: IO ()


### PR DESCRIPTION
Works on inputs such as
```
r & ((z z) r) ~ ({x (x y)} y)
```
However there seems to be a memory leak of some kind. For example, when evaluating the above net, the resulting `BUFF`
```
------------------
      NODES
ADDR   LOC LAB TAG
------------------
000000 002 000 VAR
000001 000 000 ___
000002 00A 000 VAR
000003 00F 000 SUP
000004 000 000 ___
000005 003 000 LAM
000006 000 000 ___
000007 00B 000 LAM
000008 00D 000 LAM
000009 000 000 ___
00000A 012 000 VAR
00000B 00B 000 SUB
00000C 011 000 VAR
00000D 007 000 VAR
00000E 000 000 ___
00000F 000 000 ___
000010 000 000 ___
000011 00B 000 VAR
000012 00D 000 VAR
------------------
    REDEX BAG
ADDR   LOC LAB TAG
------------------
------------------
```
Has some `SUP` and `LAM` nodes which I do not think is correct.