### PR TITLE
HVMS: Add numerics

### DIFF
--- a/src/HVMS/Extract.hs
+++ b/src/HVMS/Extract.hs
@@ -26,6 +26,8 @@ extractPCore term = case termTag term of
           tm1' <- extractPCore tm1
           tm2' <- extractPCore tm2
           return $ PSup tm1' tm2'
+      | tag == _W32_ -> do
+          return $ PU32 (termLoc term)
       | otherwise -> return PNul
 
 -- Convert a term in memory to a NCore.
@@ -58,6 +60,7 @@ extractVar loc term = case termTag term of
       | tag == _LAM_ -> extractPCore term
       | tag == _SUP_ -> extractPCore term
       | tag == _SUB_ -> return $ PVar ("v" ++ show loc)
+      | tag == _W32_ -> return $ PU32 (termLoc term)
       | otherwise    -> return PNul
 
 -- Bag and Net Extraction

--- a/src/HVMS/Extract.hs
+++ b/src/HVMS/Extract.hs
@@ -44,6 +44,14 @@ extractNCore loc term = case termTag term of
           arg' <- extractPCore arg
           ret' <- extractNCore (loc + 1) ret
           return $ NApp arg' ret'
+      | tag == _OPX_ || tag == _OPY_ -> do
+          let op  = (toEnum (fromIntegral (termLab term)))
+          let loc = termLoc term
+          arg <- get (loc + 0)
+          ret <- get (loc + 1)
+          arg' <- extractPCore arg
+          ret' <- extractNCore (loc + 1) ret
+          return $ NOp2 op arg' ret'
       | tag == _DUP_ -> do
           let loc = termLoc term
           dp1 <- get (loc + 0)

--- a/src/HVMS/Inject.hs
+++ b/src/HVMS/Inject.hs
@@ -43,6 +43,8 @@ injectPCore (PSup tm1 tm2) loc defs vars = do
   set (sup + 0) tm1
   set (sup + 1) tm2
   return (vars, termNew _SUP_ 0 sup)
+injectPCore (PU32 num) loc defs vars =
+  return (vars, termNew _W32_ 0 num)
 
 injectNCore :: NCore -> Maybe Loc -> DefMap -> VarMap -> IO (VarMap, Term)
 injectNCore (NSub name) loc defs vars = case (Map.lookup name vars, loc) of
@@ -66,6 +68,13 @@ injectNCore (NApp arg ret) loc defs vars = do
   set (app + 0) arg
   set (app + 1) ret
   return (vars, termNew _APP_ 0 app)
+injectNCore (POp2 opr arg ret) loc defs vars = do
+  loc <- allocNode 2
+  (vars, arg) <- injectPCore arg (Just (loc + 0)) defs vars
+  (vars, ret) <- injectNCore ret (Just (loc + 1)) defs vars
+  set (loc + 0) arg
+  set (loc + 1) ret
+  return (vars, termNew _OPX_ (fromIntegral $ fromEnum opr) loc)
 injectNCore (NDup dp1 dp2) loc defs vars = do
   dup <- allocNode 2
   (vars, dp1) <- injectNCore dp1 (Just (dup + 0)) defs vars

--- a/src/HVMS/Inject.hs
+++ b/src/HVMS/Inject.hs
@@ -68,7 +68,7 @@ injectNCore (NApp arg ret) loc defs vars = do
   set (app + 0) arg
   set (app + 1) ret
   return (vars, termNew _APP_ 0 app)
-injectNCore (POp2 opr arg ret) loc defs vars = do
+injectNCore (NOp2 opr arg ret) loc defs vars = do
   loc <- allocNode 2
   (vars, arg) <- injectPCore arg (Just (loc + 0)) defs vars
   (vars, ret) <- injectNCore ret (Just (loc + 1)) defs vars

--- a/src/HVMS/Parse.hs
+++ b/src/HVMS/Parse.hs
@@ -53,7 +53,7 @@ parseNCore = do
           opr <- parseOper;
           arg <- parsePCore;
           ret <- parseNCore;
-          return $ POp2 opr arg ret
+          return $ NOp2 opr arg ret
         } <|> do {
           arg <- parsePCore;
           ret <- parseNCore;

--- a/src/HVMS/Parse.hs
+++ b/src/HVMS/Parse.hs
@@ -1,8 +1,11 @@
 module HVMS.Parse where
 
+import HVMS.Type
+import HVMS.Show (operToString)
+
+import Data.Word
 import Text.Parsec
 import Text.Parsec.String
-import HVMS.Type
 
 import Debug.Trace
 import qualified Data.Map.Strict as MS
@@ -34,8 +37,7 @@ parsePCore = do
       name <- parseName
       return $ PRef name
     _ -> do
-      name <- parseName
-      return $ PVar name
+      fmap PU32 parseNum <|> fmap PVar parseName
 
 parseNCore :: Parser NCore
 parseNCore = do
@@ -46,10 +48,19 @@ parseNCore = do
       return NEra
     '(' -> do
       consume "("
-      arg <- parsePCore
-      ret <- parseNCore
+      core <-
+        do {
+          opr <- parseOper;
+          arg <- parsePCore;
+          ret <- parseNCore;
+          return $ POp2 opr arg ret
+        } <|> do {
+          arg <- parsePCore;
+          ret <- parseNCore;
+          return $ NApp arg ret
+        }
       consume ")"
-      return $ NApp arg ret
+      return core
     '{' -> do
       consume "{"
       dp1 <- parseNCore
@@ -59,6 +70,13 @@ parseNCore = do
     _ -> do
       name <- parseName
       return $ NSub name
+
+parseOper :: Parser Oper
+parseOper = do
+  let opers :: [Oper] = enumFrom (toEnum 0)
+  let operParser op = string' (operToString op) >> return op
+  choice $ map operParser opers
+
 
 parseDex :: Parser Dex
 parseDex = do
@@ -108,6 +126,12 @@ peekNextChar = spaces >> lookAhead anyChar
 
 parseName :: Parser String
 parseName = spaces >> many1 (alphaNum <|> char '_')
+
+parseNum :: Parser Word32
+parseNum = do
+  spaces
+  digits <- many1 digit
+  return $ fromIntegral (read digits :: Integer)
 
 consume :: String -> Parser String
 consume str = spaces >> string str

--- a/src/HVMS/Show.hs
+++ b/src/HVMS/Show.hs
@@ -13,12 +13,31 @@ pcoreToString (PRef nam)     = "@" ++ nam
 pcoreToString PNul           = "*"
 pcoreToString (PLam var bod) = "(" ++ ncoreToString var ++ " " ++ pcoreToString bod ++ ")"
 pcoreToString (PSup t1 t2)   = "{" ++ pcoreToString t1 ++ " " ++ pcoreToString t2 ++ "}"
+pcoreToString (PU32 num)     = show num
 
 ncoreToString :: NCore -> String
 ncoreToString (NSub nam)     = nam
 ncoreToString NEra           = "*"
 ncoreToString (NApp arg ret) = "(" ++ pcoreToString arg ++ " " ++ ncoreToString ret ++ ")"
 ncoreToString (NDup d1 d2)   = "{" ++ ncoreToString d1 ++ " " ++ ncoreToString d2 ++ "}"
+
+operToString :: Oper -> String
+operToString OP_ADD = "+"
+operToString OP_SUB = "-"
+operToString OP_MUL = "*"
+operToString OP_DIV = "/"
+operToString OP_MOD = "%"
+operToString OP_EQ  = "=="
+operToString OP_NE  = "!="
+operToString OP_LT  = "<"
+operToString OP_GT  = ">"
+operToString OP_LTE = "<="
+operToString OP_GTE = ">="
+operToString OP_AND = "&"
+operToString OP_OR  = "|"
+operToString OP_XOR = "^"
+operToString OP_LSH = "<<"
+operToString OP_RSH = ">>"
 
 dexToString :: Dex -> String
 dexToString (neg, pos) = ncoreToString neg ++ " ~ " ++ pcoreToString pos
@@ -44,6 +63,9 @@ tagToString tag
   | tag == _SUP_ = "SUP"
   | tag == _DUP_ = "DUP"
   | tag == _REF_ = "REF"
+  | tag == _OPX_ = "OPX"
+  | tag == _OPY_ = "OPY"
+  | tag == _W32_ = "W32"
   | otherwise    = "???"
 
 labToString :: Lab -> String

--- a/src/HVMS/Show.hs
+++ b/src/HVMS/Show.hs
@@ -16,10 +16,11 @@ pcoreToString (PSup t1 t2)   = "{" ++ pcoreToString t1 ++ " " ++ pcoreToString t
 pcoreToString (PU32 num)     = show num
 
 ncoreToString :: NCore -> String
-ncoreToString (NSub nam)     = nam
-ncoreToString NEra           = "*"
-ncoreToString (NApp arg ret) = "(" ++ pcoreToString arg ++ " " ++ ncoreToString ret ++ ")"
-ncoreToString (NDup d1 d2)   = "{" ++ ncoreToString d1 ++ " " ++ ncoreToString d2 ++ "}"
+ncoreToString (NSub nam)        = nam
+ncoreToString NEra              = "*"
+ncoreToString (NApp arg ret)    = "(" ++ pcoreToString arg ++ " " ++ ncoreToString ret ++ ")"
+ncoreToString (NDup d1 d2)      = "{" ++ ncoreToString d1 ++ " " ++ ncoreToString d2 ++ "}"
+ncoreToString (NOp2 op arg ret) = "(" ++ operToString op ++ " " ++ pcoreToString arg ++ " " ++ ncoreToString ret ++ ")"
 
 operToString :: Oper -> String
 operToString OP_ADD = "+"

--- a/src/HVMS/Type.hs
+++ b/src/HVMS/Type.hs
@@ -22,7 +22,7 @@ data NCore
   = NSub String
   | NEra
   | NApp PCore NCore
-  | POp2 Oper  PCore NCore
+  | NOp2 Oper  PCore NCore
   | NDup NCore NCore
   deriving (Show, Eq)
 

--- a/src/HVMS/Type.hs
+++ b/src/HVMS/Type.hs
@@ -15,14 +15,23 @@ data PCore
   | PNul
   | PLam NCore PCore
   | PSup PCore PCore
+  | PU32 Word32
   deriving (Show, Eq)
 
 data NCore
   = NSub String
   | NEra
   | NApp PCore NCore
+  | POp2 Oper  PCore NCore
   | NDup NCore NCore
   deriving (Show, Eq)
+
+data Oper
+  = OP_ADD | OP_SUB | OP_MUL | OP_DIV
+  | OP_MOD | OP_EQ  | OP_NE  | OP_LT
+  | OP_GT  | OP_LTE | OP_GTE | OP_AND
+  | OP_OR  | OP_XOR | OP_LSH | OP_RSH
+  deriving (Show, Eq, Enum)
 
 -- A Redex is a pair of Terms (trees connected by their main ports)
 type Dex = (NCore, PCore)
@@ -50,7 +59,7 @@ type Loc  = Word32
 type Term = Word64
 
 -- Runtime constants
-_VAR_, _SUB_, _NUL_, _ERA_, _LAM_, _APP_, _SUP_, _DUP_, _REF_ :: Tag
+_VAR_, _SUB_, _NUL_, _ERA_, _LAM_, _APP_, _SUP_, _DUP_, _REF_, _OPX_, _OPY_, _W32_ :: Tag
 _VAR_ = 0x01
 _SUB_ = 0x02
 _NUL_ = 0x03
@@ -60,6 +69,9 @@ _APP_ = 0x06
 _SUP_ = 0x07
 _DUP_ = 0x08
 _REF_ = 0x09
+_OPX_ = 0x0A
+_OPY_ = 0x0B
+_W32_ = 0x0C
 
 _VOID_ :: Term
 _VOID_ = 0x0


### PR DESCRIPTION
Adds numerics. Numerics are represented in the same way as lazy mode, with
- `OPX` and `OPY` nodes storing operators and information about which arguments are reduced
  - When injecting the AST into memory, only `OPX` is created. `OPX` is converted to `OPY` when the argument on its active pair is reduced and is a W32.
- W32 nodes holding untagged 32-bit numbers.

For example, this program
```
@div3 = ((/ 3 r) r)

@id = (x x)

@compose_self = ({x (x y)} y)

@main = r & (12 r) ~ @div3
```
normalizes to `4` as expected.