### PR TITLE
using mmap instead of malloc

### DIFF
--- a/src/HVML/Runtime.c
+++ b/src/HVML/Runtime.c
@@ -1185,17 +1185,47 @@ Term FRESH_f(Term ref) {
 // --------------
 
 void hvm_init() {
-  // FIXME: use mmap instead
-  HVM.sbuf  = malloc((1ULL << 32) * sizeof(Term));
-  HVM.spos  = malloc(sizeof(u64));
+  // Allocate memory using mmap
+  HVM.sbuf  = mmap(NULL, (1ULL << 32) * sizeof(Term), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (HVM.sbuf == MAP_FAILED) {
+    perror("mmap failed for sbuf");
+    exit(EXIT_FAILURE);
+  }
+
+  HVM.spos  = mmap(NULL, sizeof(u64), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (HVM.spos == MAP_FAILED) {
+    perror("mmap failed for spos");
+    exit(EXIT_FAILURE);
+  }
   *HVM.spos = 0;
-  HVM.heap  = malloc((1ULL << 32) * sizeof(ATerm));
-  HVM.size  = malloc(sizeof(u64));
-  HVM.itrs  = malloc(sizeof(u64));
+
+  HVM.heap  = mmap(NULL, (1ULL << 32) * sizeof(ATerm), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (HVM.heap == MAP_FAILED) {
+    perror("mmap failed for heap");
+    exit(EXIT_FAILURE);
+  }
+
+  HVM.size  = mmap(NULL, sizeof(u64), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (HVM.size == MAP_FAILED) {
+    perror("mmap failed for size");
+    exit(EXIT_FAILURE);
+  }
   *HVM.size = 1;
+
+  HVM.itrs  = mmap(NULL, sizeof(u64), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (HVM.itrs == MAP_FAILED) {
+    perror("mmap failed for itrs");
+    exit(EXIT_FAILURE);
+  }
   *HVM.itrs = 0;
-  HVM.frsh  = malloc(sizeof(u64));
+
+  HVM.frsh  = mmap(NULL, sizeof(u64), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (HVM.frsh == MAP_FAILED) {
+    perror("mmap failed for frsh");
+    exit(EXIT_FAILURE);
+  }
   *HVM.frsh = 0x20;
+
   HVM.book[SUP_F] = SUP_f;
   HVM.book[DUP_F] = DUP_f;
   HVM.book[LOG_F] = LOG_f;
@@ -1203,12 +1233,25 @@ void hvm_init() {
 }
 
 void hvm_free() {
-  free(HVM.sbuf);
-  free(HVM.spos);
-  free(HVM.heap);
-  free(HVM.size);
-  free(HVM.itrs);
-  free(HVM.frsh);
+  // Free memory using munmap
+  if (munmap(HVM.sbuf, (1ULL << 32) * sizeof(Term)) == -1) {
+    perror("munmap failed for sbuf");
+  }
+  if (munmap(HVM.spos, sizeof(u64)) == -1) {
+    perror("munmap failed for spos");
+  }
+  if (munmap(HVM.heap, (1ULL << 32) * sizeof(ATerm)) == -1) {
+    perror("munmap failed for heap");
+  }
+  if (munmap(HVM.size, sizeof(u64)) == -1) {
+    perror("munmap failed for size");
+  }
+  if (munmap(HVM.itrs, sizeof(u64)) == -1) {
+    perror("munmap failed for itrs");
+  }
+  if (munmap(HVM.frsh, sizeof(u64)) == -1) {
+    perror("munmap failed for frsh");
+  }
 }
 
 State* hvm_get_state() {


### PR DESCRIPTION
Simply replaces `malloc` allocation with `mmap`. 

## Performance reports after:

## MacOS
MIPS diff:
Bench_cnots: +1.24% 
Bench_count: +1.5%
Bench_sum_range: +1.28% 
Enum_bin: +0.9% 
Fuse_inc: +13.6% 
Enum_lam_smart: +1.23%

## X86
MIPs diff
Performances on x86 did not improve / inconclusive, e.g from -1% to +1% on the runs.

## X86


## MacOs individual reports
### bench_cnots

- *malloc*:
WORK: 117440614 interactions
TIME: 0.9676010 seconds
SIZE: 335544641 nodes
PERF: 121.373 MIPS

- *mmap*:
WORK: 117440614 interactions
TIME: 0.9557490 seconds
SIZE: 335544641 nodes
PERF: 122.878 MIPS

### bench count:
- *malloc*:
WORK: 12000000004 interactions
TIME: 1.0456890 seconds
SIZE: 3 nodes
PERF: 11475.687 MIPS

- *mmap*:
WORK: 12000000004 interactions
TIME: 1.0303480 seconds
SIZE: 3 nodes
PERF: 11646.550 MIPS

### bench sum range:

- *malloc*:
WORK: 600000007 interactions
TIME: 0.1483380 seconds
SIZE: 100000005 nodes
PERF: 4044.817 MIPS

- *mmap*:
WORK: 600000007 interactions
TIME: 0.1464510 seconds
SIZE: 100000005 nodes
PERF: 4096.933 MIPS

### enum bin:

- *malloc*:
WORK: 390749326 interactions
TIME: 3.1301000 seconds
SIZE: 1742192467 nodes
PERF: 124.836 MIPS

- *mmap*:
WORK: 390749326 interactions
TIME: 3.1006360 seconds
SIZE: 1742192467 nodes
PERF: 126.022 MIPS

### fuse inc

- *maloc*:
WORK: 11472 interactions
TIME: 0.0002010 seconds
SIZE: 37339 nodes
PERF: 57.075 MIPS

- *mmap*:
WORK: 11472 interactions
TIME: 0.0001770 seconds
SIZE: 37339 nodes
PERF: 64.814 MIPS

### enum lam smart:

- *malloc*
WORK: 189534 interactions
TIME: 0.0055890 seconds
SIZE: 839736 nodes
PERF: 33.912 MIPS

- *mmap*:
WORK: 189534 interactions
TIME: 0.0055210 seconds
SIZE: 839736 nodes
PERF: 34.330 MIPS

## X86 individual reports (on 16 allocation on runtime)
### bench count:
- *malloc*:
! a = 4000
a
WORK: 12004 interactions
TIME: 0.0000747 seconds
SIZE: 3 nodes
PERF: 160.591 MIPS

- *mmap*:
! a = 4000
a
WORK: 12004 interactions
TIME: 0.0000747 seconds
SIZE: 3 nodes
PERF: 160.705 MIPS

### bench sum range

- *malloc*:
! a = 12497500
a
WORK: 60007 interactions
TIME: 0.0002372 seconds
SIZE: 10005 nodes
PERF: 252.992 MIPS

- *mmap*:
! a = 12497500
a
WORK: 60007 interactions
TIME: 0.0002528 seconds
SIZE: 10005 nodes
PERF: 237.388 MIPS

### enum bin 
(4 bit enum)

- *malloc*:
```
! a = &2{* &1{* &1{&2{* *} &2{* λb ((b 3) 3)}}}}
a
```
WORK: 1918 interactions
TIME: 0.0001612 seconds
SIZE: 8043 nodes
PERF: 11.901 MIPS

- *mmap*:
! a = &2{* &1{* &1{&2{* *} &2{* λb ((b 3) 3)}}}}
a
WORK: 1918 interactions
TIME: 0.0001714 seconds
SIZE: 8043 nodes
PERF: 11.192 MIPS

### enum lam smart
(with nested lambdas depth=3)

```
! a = &1{&1{&1{* &1{&1{* &1{* &2{* &2{* &2{&2{* &2{&2{* &2{* &2{* *}}} &4{* &4{* &4{* *}}}}} *}}}}} &1{&1{* &1{&1{* &1{&1{* &1{* *}} &1{* *}}} &2{* &2{&2{* &2{* *}} &2{* *}}}}} *}}} &1{&1{* &1{&1{&1{* &1{&1{* &1{* *}} &1{* *}}} &1{* *}} &2{&2{* &2{&2{* &2{* *}} &2{* *}}} &2{* *}}}} *}} *}
a
```

- *malloc*:
WORK: 12236 interactions
TIME: 0.0008063 seconds
SIZE: 60357 nodes
PERF: 15.176 MIPS

- *mmap*:
WORK: 12236 interactions
TIME: 0.0007667 seconds
SIZE: 60357 nodes
PERF: 15.958 MIPS

### fuse inc

- *malloc*:
! a = 1234567
a
WORK: 11472 interactions
TIME: 0.0005718 seconds
SIZE: 37339 nodes
PERF: 20.062 MIPS

- *mmap*:
WORK: 11472 interactions
TIME: 0.0005820 seconds
SIZE: 37339 nodes
PERF: 19.713 MIPS
