### PR TITLE
checking variables affine, error when used more than once

### DIFF
--- a/src/HVML/Compile.hs
+++ b/src/HVML/Compile.hs
@@ -21,7 +21,6 @@ data CompileState = CompileState
   , tabs :: Int
   , bins :: MS.Map String String  -- var_name => binder_host
   , vars :: [(String, String)]    -- [(var_name, var_host)]
-  , usageCounts :: MS.Map String Int  -- var_name => usage count
   , code :: [String]
   }
 
@@ -49,7 +48,7 @@ compileWith cmp book fid =
   let copy   = fst (fst (mget (fidToFun book) fid)) in
   let args   = snd (fst (mget (fidToFun book) fid)) in
   let core   = snd (mget (fidToFun book) fid) in
-  let state  = CompileState 0 0 MS.empty [] MS.empty [] in
+  let state  = CompileState 0 0 MS.empty [] [] in
   let result = runState (cmp book fid core copy args) state in
   unlines $ reverse $ code (snd result)
 
@@ -63,7 +62,7 @@ tabDec :: Compile ()
 tabDec = modify $ \st -> st { tabs = tabs st - 1 }
 
 bind :: String -> String -> Compile ()
-bind var host = do modify $ \st -> st { bins = MS.insert var host (bins st) , usageCounts = MS.insert var 0 (usageCounts st) }
+bind var host = modify $ \st -> st { bins = MS.insert var host (bins st) }
 
 fresh :: String -> Compile String
 fresh name = do
@@ -86,7 +85,6 @@ compileFull book fid core copy args = do
     bind argName argTerm
   result <- compileFullCore book fid core "root"
   st <- get
-  -- Check for unbound variables and fail at compile time
   forM_ (vars st) $ \ (var, host) -> do
     binsMap <- gets bins
     case MS.lookup var binsMap of
@@ -97,14 +95,11 @@ compileFull book fid core copy args = do
   emit "}"
 
 compileFullVar :: String -> String -> Compile String
-compileFullVar var host =  do
-  binsMap <- gets bins
-  usageCountsMap <- gets usageCounts
-  case MS.lookup var binsMap of
+compileFullVar var host = do
+  bins <- gets bins
+  case MS.lookup var bins of
     Just entry -> do
-      let count = MS.findWithDefault 0 var usageCountsMap
-      when (count >= 1) $ error $ "Compile error: Variable '" ++ var ++ "' used more than once (affine violation)"
-      modify $ \s -> s { usageCounts = MS.insert var (count + 1) usageCountsMap }
+      modify $ \s -> s { bins = MS.delete var bins }
       return entry
     Nothing -> do
       modify $ \s -> s { vars = (var, host) : vars s }
@@ -690,17 +685,13 @@ compileFastCore book fid (Ref rNam rFid rArg) reuse = do
     sequence_ [emit $ "set(" ++ refNam ++ " + " ++ show i ++ ", " ++ argT ++ ");" | (i,argT) <- zip [0..] argsT]
     return $ "term_new(REF, " ++ show rFid ++ ", " ++ refNam ++ ")"
 
-
 -- Compiles a variable in fast mode
 compileFastVar :: String -> Compile String
 compileFastVar var = do
-  binsMap <- gets bins
-  usageCountsMap <- gets usageCounts
-  case MS.lookup var binsMap of
+  bins <- gets bins
+  case MS.lookup var bins of
     Just entry -> do
-      let count = MS.findWithDefault 0 var usageCountsMap
-      when (count >= 1) $ error $ "Compile error: Variable '" ++ var ++ "' used more than once (affine violation)"
-      modify $ \s -> s { usageCounts = MS.insert var (count + 1) usageCountsMap }
+      modify $ \s -> s { bins = MS.delete var bins }
       return entry
     Nothing -> do
       return "<ERR>"

--- a/src/HVML/Compile.hs
+++ b/src/HVML/Compile.hs
@@ -99,7 +99,7 @@ compileFullVar var host = do
   bins <- gets bins
   case MS.lookup var bins of
     Just entry -> do
-      modify $ \s -> s { bins = MS.delete var bins }
+      when (head var /= '&') $ modify $ \s -> s { bins = MS.delete var bins }
       return entry
     Nothing -> do
       modify $ \s -> s { vars = (var, host) : vars s }
@@ -691,7 +691,7 @@ compileFastVar var = do
   bins <- gets bins
   case MS.lookup var bins of
     Just entry -> do
-      modify $ \s -> s { bins = MS.delete var bins }
+      -- when (head var /= '&') $ modify $ \s -> s { bins = MS.delete var bins }
       return entry
     Nothing -> do
       return "<ERR>"

--- a/src/HVML/Inject.hs
+++ b/src/HVML/Inject.hs
@@ -32,13 +32,13 @@ injectCore _ Era loc = do
 injectCore _ (Var nam) loc = do
   argsMap <- gets args
   usageCounts <- gets usageCounts
+
   case MS.lookup nam argsMap of
     Just term -> do
       let count = MS.findWithDefault 0 nam usageCounts
-      when (count >= 1) $ lift $ error ("Variable " ++ nam ++ " used more than once (affine violation)")
-      modify $ \s -> s { usageCounts = MS.insert nam (count + 1) usageCounts }
+      when (count >= 1) $ lift $ error ("Variable " ++ nam ++ " used more than once (affine violation) in term")
       lift $ set loc term
-      when (head nam /= '&') $ modify $ \s -> s { args = MS.delete nam (args s) }
+      when (head nam /= '&') $ modify $ \s -> s { args = MS.delete nam (args s) , usageCounts = MS.insert nam (count + 1) usageCounts }
     Nothing -> do
       let count = MS.findWithDefault 0 nam usageCounts
       when (count >= 1) $ lift $ error ("Variable " ++ nam ++ " used more than once (affine violation)")

--- a/src/HVML/Inject.hs
+++ b/src/HVML/Inject.hs
@@ -35,13 +35,13 @@ injectCore _ (Var nam) loc = do
   case MS.lookup nam argsMap of
     Just term -> do
       let count = MS.findWithDefault 0 nam usageCounts
-      when (count >= 1) $ lift $ error ("Variable " ++ nam ++ " used more than once")
+      when (count >= 1) $ lift $ error ("Variable " ++ nam ++ " used more than once (affine violation)")
       modify $ \s -> s { usageCounts = MS.insert nam (count + 1) usageCounts }
       lift $ set loc term
       when (head nam /= '&') $ modify $ \s -> s { args = MS.delete nam (args s) }
     Nothing -> do
       let count = MS.findWithDefault 0 nam usageCounts
-      when (count >= 1) $ lift $ error ("Variable " ++ nam ++ " used more than once")
+      when (count >= 1) $ lift $ error ("Variable " ++ nam ++ " used more than once (affine violation)")
       modify $ \s -> s { vars = (nam, loc) : vars s, usageCounts = MS.insert nam (count + 1) usageCounts }
 
 injectCore book (Let mod nam val bod) loc = do


### PR DESCRIPTION
Interepreted mode checks for affinety, and output the affine violation error.

Compiled mode was kept simple to be fast, so the error is just unbound variable, but catches affine as well.