### PR TITLE
better parsing errors

### DIFF
--- a/src/HVML/Main.hs
+++ b/src/HVML/Main.hs
@@ -101,7 +101,7 @@ cliRun filePath debug compiled mode showStats hideQuotes strArgs = do
   -- Initialize the HVM
   hvmInit
   code <- readFile' filePath
-  book <- doParseBook code
+  book <- doParseBook filePath code
   -- Create the C file content
   let decls = compileHeaders book
   let funcs = map (\ (fid, _) -> compile book fid) (MS.toList (fidToFun book))

--- a/src/HVML/Parse.hs
+++ b/src/HVML/Parse.hs
@@ -461,9 +461,11 @@ parseADTCtr = do
 
 parseBook :: ParserM [(String, ((Bool, [(Bool,String)]), Core))]
 parseBook = do
+  skip
   defs <- many $ do
+    def <- choice [parseTopImp, parseTopADT, parseTopDef]
     skip
-    choice [parseTopImp, parseTopADT, parseTopDef]
+    return def
   try $ skip >> eof
   return $ concat defs
 

--- a/src/HVML/Parse.hs
+++ b/src/HVML/Parse.hs
@@ -12,7 +12,6 @@ import Data.Maybe
 import Data.Word
 import Debug.Trace
 import HVML.Show
-import HVML.Check (checkVars)
 import HVML.Type
 import Highlight (highlightError)
 import System.Console.ANSI

--- a/src/HVML/Type.hs
+++ b/src/HVML/Type.hs
@@ -318,7 +318,7 @@ _LOG_F_ :: Lab
 _LOG_F_ = 0xFFD
 
 primitives :: [(String, Lab)]
-primitives = 
+primitives =
   [ ("SUP", _SUP_F_)
   , ("DUP", _DUP_F_)
   , ("LOG", _LOG_F_)


### PR DESCRIPTION
1. Checks affinity of variables.
2. Shows better context for errors when parsing imported files.

An example catching a duplicate use of a variable through imports:
<img width="265" alt="image" src="https://github.com/user-attachments/assets/31580a56-fbf8-4421-a20e-8423c8d2054d" />

Note the location isn't perfect b/c names are checked after they are consumed, but it's better than before.
