### PR TITLE
f32 i32 numerics

### DIFF
--- a/src/HVMS/Extract.hs
+++ b/src/HVMS/Extract.hs
@@ -29,7 +29,9 @@ extractPCore term = case termTag term of
     tm1' <- extractPCore tm1
     tm2' <- extractPCore tm2
     return $ PSup tm1' tm2'
-  W32 -> return $ PU32 (termLoc term)
+  U32 -> return $ PU32 (termLoc term)
+  I32 -> return $ PI32 (word32ToInt32 $ termLoc term)
+  F32 -> return $ PF32 (word32ToFloat $ termLoc term)
 
 -- Convert a term in memory to a NCore.
 -- The optional location is the location of the term
@@ -76,7 +78,9 @@ extractVar loc term = case termTag term of
   LAM -> extractPCore term
   SUP -> extractPCore term
   SUB -> return $ PVar ("v" ++ show loc)
-  W32 -> return $ PU32 (termLoc term)
+  U32 -> return $ PU32 (termLoc term)
+  I32 -> return $ PI32 (word32ToInt32 $ termLoc term)
+  F32 -> return $ PF32 (word32ToFloat $ termLoc term)
   tag -> do
     putStrLn $ "extractVar: unexpected tag " ++ show tag
     return PNul

--- a/src/HVMS/Inject.hs
+++ b/src/HVMS/Inject.hs
@@ -45,7 +45,11 @@ injectPCore (PSup tm1 tm2) loc defs vars = do
   set (sup + 1) tm2
   return (vars, termNew SUP 0 sup)
 injectPCore (PU32 num) loc defs vars =
-  return (vars, termNew W32 0 num)
+  return (vars, termNew U32 0 num)
+injectPCore (PI32 num) loc defs vars =
+  return (vars, termNew I32 0 (int32ToWord32 num))
+injectPCore (PF32 num) loc defs vars =
+  return (vars, termNew F32 0 (floatToWord32 num))
 
 injectNCore :: NCore -> Maybe Loc -> DefMap -> VarMap -> IO (VarMap, Term)
 injectNCore (NSub name) loc defs vars = case (Map.lookup name vars, loc) of

--- a/src/HVMS/Show.hs
+++ b/src/HVMS/Show.hs
@@ -1,6 +1,7 @@
 module HVMS.Show where
 
 import Data.Word
+import Data.List
 import Numeric (showHex)
 import HVMS.Type
 
@@ -14,13 +15,18 @@ pcoreToString PNul           = "*"
 pcoreToString (PLam var bod) = "(" ++ ncoreToString var ++ " " ++ pcoreToString bod ++ ")"
 pcoreToString (PSup t1 t2)   = "{" ++ pcoreToString t1 ++ " " ++ pcoreToString t2 ++ "}"
 pcoreToString (PU32 num)     = show num
+pcoreToString (PI32 num)     = show num
+pcoreToString (PF32 num)     = show num
 
 ncoreToString :: NCore -> String
 ncoreToString (NSub nam)        = nam
 ncoreToString NEra              = "*"
-ncoreToString (NApp arg ret)    = "(" ++ pcoreToString arg ++ " " ++ ncoreToString ret ++ ")"
-ncoreToString (NDup d1 d2)      = "{" ++ ncoreToString d1 ++ " " ++ ncoreToString d2 ++ "}"
-ncoreToString (NOp2 op arg ret) = "(" ++ operToString op ++ " " ++ pcoreToString arg ++ " " ++ ncoreToString ret ++ ")"
+ncoreToString (NApp arg ret)    = "("  ++ pcoreToString arg ++ " " ++ ncoreToString ret ++ ")"
+ncoreToString (NDup d1 d2)      = "{"  ++ ncoreToString d1  ++ " " ++ ncoreToString d2  ++ "}"
+ncoreToString (NOp2 op arg ret) = "("  ++ operToString op   ++ " " ++ pcoreToString arg ++ " " ++ ncoreToString ret ++ ")"
+ncoreToString (NMat ret arms)   = "?(" ++ ncoreToString ret ++ " " ++ armsString ++ ")"
+  where
+    armsString = intercalate " " (map pcoreToString arms)
 
 operToString :: Oper -> String
 operToString OP_ADD = "+"

--- a/src/HVMS/Type.hs
+++ b/src/HVMS/Type.hs
@@ -1,6 +1,8 @@
 module HVMS.Type where
 
 import Data.Word
+import GHC.Float
+import GHC.Int
 import Foreign.C.String
 import qualified Data.Map.Strict as MS
 
@@ -16,6 +18,8 @@ data PCore
   | PLam NCore PCore
   | PSup PCore PCore
   | PU32 Word32
+  | PI32 Int32
+  | PF32 Float
   deriving (Show, Eq)
 
 data NCore
@@ -72,7 +76,9 @@ data Tag
   | REF
   | OPX
   | OPY
-  | W32
+  | U32
+  | I32
+  | F32
   | MAT
   deriving (Enum, Eq, Show)
 
@@ -152,3 +158,15 @@ foreign import ccall unsafe "Runtime.c dump_buff"
 
 termOper :: Term -> Oper
 termOper term = (toEnum (fromIntegral (termLab term)))
+
+foreign import ccall unsafe "Runtime.c u32_to_i32"
+  word32ToInt32 :: Word32 -> Int32
+
+foreign import ccall unsafe "Runtime.c u32_to_f32"
+  word32ToFloat :: Word32 -> Float
+
+foreign import ccall unsafe "Runtime.c i32_to_u32"
+  int32ToWord32 :: Int32 -> Word32
+
+foreign import ccall unsafe "Runtime.c f32_to_u32"
+  floatToWord32 :: Float -> Word32


### PR DESCRIPTION
Adds support for f32/i32 numerics on hvms
```
@main = r & (/ 2.0 r) ~ 3.1415
```
which results in `1.57075` as expected.

i32 and f32 can't be matched on.