### PR TITLE
use PRIu64 for platform-specific u64 format specifier

### DIFF
--- a/src/HVML/Main.hs
+++ b/src/HVML/Main.hs
@@ -209,7 +209,7 @@ genMain book =
     , "  Term root = term_new(REF, "++show mainFid++", 0);"
     , "  normal(root);"
     , "  double time = (double)(clock() - start) / CLOCKS_PER_SEC * 1000;"
-    , "  printf(\"WORK: %llu interactions\\n\", get_itr());"
+    , "  printf(\"WORK: %\"PRIu64\" interactions\\n\", get_itr());"
     , "  printf(\"TIME: %.3fs seconds\\n\", time / 1000.0);"
     , "  printf(\"SIZE: %u nodes\\n\", get_len());"
     , "  printf(\"PERF: %.3f MIPS\\n\", (get_itr() / 1000000.0) / (time / 1000.0));"

--- a/src/HVML/Runtime.c
+++ b/src/HVML/Runtime.c
@@ -1,5 +1,6 @@
 //./Type.hs//
 
+#include <inttypes.h>
 #include <stdatomic.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
On ARM (eg macOS) it seems that `%llu` is the correct format specifier for `uint64_t`. However on intel machines using `%llu` results in a compilation warning:
<img width="535" alt="image" src="https://github.com/user-attachments/assets/3a594d39-feaf-46e0-bd89-163b5d81f0a9" />

Using `PRIu64` from `<inttypes.h>` fixes this.